### PR TITLE
Added posibility to skip exec existance check.

### DIFF
--- a/ImageConversion/src/handlers/imagemagick_base.php
+++ b/ImageConversion/src/handlers/imagemagick_base.php
@@ -396,7 +396,7 @@ class ezcImageImagemagickBaseHandler extends ezcImageMethodcallHandler
         {
             $this->binary = ezcBaseFeatures::getImageConvertExecutable();
         }
-        else if ( file_exists( $settings->options['binary'] ) )
+        else if ( ( isset( $settings->options['skip_exec_check'] ) && $settings->options['skip_exec_check'] ) || file_exists( $settings->options['binary'] ) )
         {
             $this->binary = $settings->options['binary'];
         }


### PR DESCRIPTION
Added posibility to skip exec existance check. This can fix problems when file_exists() returns false for files that exist but are not in open_basedir. This can also be used to solve issue #17972.
